### PR TITLE
Add global timeout setters and a HEAD method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Wrapper class around the QNetworkAccessManager to simplify performing HTTP reque
   - Sets the Bearer Token for authentication.
 - `void get(const QString &url) noexcept`:
   - Performs a GET request asynchronously.
+- `void setGlobalTimeout(std::chrono::milliseconds ms)`:
+  - Set the qthttpclient's transfer timeout to the given value (in milliseconds).
+- `void resetGlobalTimeout()`:
+  - Reset the qthttpclient timeout to Qt's default.
+- `void HEAD(const QString& url) noexcept`:
+  - Performs a HEAD request asynchronously.
 - `void post(const QString &url, const QByteArray &data) noexcept`:
   - Performs a POST request asynchronously.
 - `void put(const QString &url, const QByteArray &data) noexcept`:
@@ -69,6 +75,8 @@ Wrapper class around the QNetworkAccessManager to simplify performing HTTP reque
   - Performs a DELETE request asynchronously.
 - `QByteArray get_sync(const QString &url)`:
   - Performs a synchronous GET request and blocks until the response arrives.
+- `QByteArray head_sync(const QString& url)`:
+  - Performs a synchronous HEAD request and blocks until the response arrives.
 - `QByteArray post_sync(const QString &url, const QByteArray &data)`:
   - Performs a synchronous POST request and blocks until the response arrives.
 - `QByteArray put_sync(const QString &url, const QByteArray &data)`:

--- a/httpclient.cpp
+++ b/httpclient.cpp
@@ -37,6 +37,14 @@ void HttpClient::setBearerToken(const QString& jwtToken) {
     HttpClient::token = jwtToken;
 }
 
+void HttpClient::setGlobalTimeout(std::chrono::milliseconds ms) {
+    manager->setTransferTimeout(ms != std::chrono::milliseconds::zero() ? ms : QNetworkRequest::DefaultTransferTimeout);
+}
+
+void HttpClient::resetGlobalTimeout() {
+    manager->setTransferTimeout(QNetworkRequest::DefaultTransferTimeout);
+}
+
 // Initialize static token
 QString HttpClient::token = QString();
 
@@ -45,6 +53,14 @@ void HttpClient::get(const QString& url) noexcept {
     QNetworkRequest request(qUrl);
     setHeaders(&request);
     QNetworkReply* reply = manager->get(request);
+    connect(reply, &QNetworkReply::finished, this, &HttpClient::onReplyFinished);
+}
+
+void HttpClient::head(const QString& url) noexcept {
+    QUrl qUrl(url);
+    QNetworkRequest request(qUrl);
+    setHeaders(&request);
+    QNetworkReply *reply = manager->head(request);
     connect(reply, &QNetworkReply::finished, this, &HttpClient::onReplyFinished);
 }
 
@@ -101,6 +117,14 @@ QByteArray HttpClient::get_sync(const QString& url) {
     QNetworkRequest request(qUrl);
     setHeaders(&request);
     QNetworkReply* reply = manager->get(request);
+    return waitForResponse(reply);
+}
+
+QByteArray HttpClient::head_sync(const QString& url) {
+    QUrl qUrl(url);
+    QNetworkRequest request(qUrl);
+    setHeaders(&request);
+    QNetworkReply *reply = manager->head(request);
     return waitForResponse(reply);
 }
 

--- a/include/httpclient/httpclient.hpp
+++ b/include/httpclient/httpclient.hpp
@@ -102,6 +102,9 @@ public:
      */
     static void setRootCA(const QString& certPath);
 
+    void setGlobalTimeout(std::chrono::milliseconds ms);
+    void resetGlobalTimeout();
+
     /**
      * @brief Set the Bearer Token string. This will be used to Bearer Auth.
      *
@@ -116,6 +119,14 @@ public:
      * @param url QString
      */
     void get(const QString& url) noexcept;
+
+    /**
+     * @brief Perform a HEAD request asyncronously. You will need to access the response by connecting
+     * to the success signal and error to error signal.
+     *
+     * @param url QString
+     */
+    void head(const QString& url) noexcept;
 
     /**
      * @brief Perform a POST request asyncronously. You will need to access the response by connecting
@@ -156,6 +167,12 @@ public:
      * Returns data in request body if successful or throws a NetworkException if it fails.
      */
     QByteArray get_sync(const QString& url);
+
+    /** Perform syncronous HEAD request and block until the response arrives
+     * Returns data in request body if successful or throws a NetworkException if it fails.
+     * You must catch this error to avoid segmentation faults.
+     */
+    QByteArray head_sync(const QString& url);
 
     /** Perform syncronous POST request and block until the response arrives
      * Returns data in request body if successful or throws a NetworkException if it fails.


### PR DESCRIPTION
* Add HEAD command to verify a remote URL works as expected.
* Add global timeout to the library to fail faster in case a remote host is misbehaving.