### PR TITLE
User Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ Wrapper class around the QNetworkAccessManager to simplify performing HTTP reque
   - Set the qthttpclient's transfer timeout to the given value (in milliseconds).
 - `void resetGlobalTimeout()`:
   - Reset the qthttpclient timeout to Qt's default.
-- `void HEAD(const QString& url) noexcept`:
+- `void setGlobalUserAgent(const QString &user_agent_signature)`:
+  - Set the qthttpclient's global User Agent value to the parameter.
+- `void resetGlobalUserAgent()`:
+  - Reset the qthttpclient global User Agent value.
+- `void head(const QString& url) noexcept`:
   - Performs a HEAD request asynchronously.
 - `void post(const QString &url, const QByteArray &data) noexcept`:
   - Performs a POST request asynchronously.

--- a/httpclient.cpp
+++ b/httpclient.cpp
@@ -33,6 +33,14 @@ void HttpClient::setRootCA(const QString& certPath) {
     file.close();
 }
 
+void HttpClient::setGlobalUserAgent(const QString &user_agent_signature) {
+    user_agent_override = user_agent_signature;
+}
+
+void HttpClient::resetGlobalUserAgent() {
+    user_agent_override = "";
+}
+
 void HttpClient::setBearerToken(const QString& jwtToken) {
     HttpClient::token = jwtToken;
 }
@@ -47,6 +55,7 @@ void HttpClient::resetGlobalTimeout() {
 
 // Initialize static token
 QString HttpClient::token = QString();
+QString HttpClient::user_agent_override = QString();
 
 void HttpClient::get(const QString& url) noexcept {
     QUrl qUrl(url);
@@ -172,6 +181,9 @@ void HttpClient::setHeaders(QNetworkRequest* request) {
     // Add authorization header if token is set
     if (!token.isEmpty()) {
         request->setRawHeader("Authorization", QString("Bearer ").append(token).toLocal8Bit());
+    }
+    if (!user_agent_override.isEmpty()) {
+        request->setHeader(QNetworkRequest::KnownHeaders::UserAgentHeader, user_agent_override);
     }
 }
 

--- a/include/httpclient/httpclient.hpp
+++ b/include/httpclient/httpclient.hpp
@@ -105,6 +105,9 @@ public:
     void setGlobalTimeout(std::chrono::milliseconds ms);
     void resetGlobalTimeout();
 
+    void setGlobalUserAgent(const QString &user_agent_signature);
+    void resetGlobalUserAgent();
+
     /**
      * @brief Set the Bearer Token string. This will be used to Bearer Auth.
      *
@@ -200,6 +203,7 @@ private:
     void setHeaders(QNetworkRequest* request);
 
     static QString token;  // The JWT
+    static QString user_agent_override;  // The User Agent, if set by the user
 
     // Used by all syncronous method to process reply, read data and return it to caller
     // and is responsible for throwing the NetworkException is the reply failed or status


### PR DESCRIPTION
* Added a user agent setter in cases where remotes look at the user agent for a request and block swathes of similar-looking User Agent strings
* Fixed a method name nit in the readme